### PR TITLE
Support integers and booleans in target rules

### DIFF
--- a/ldclient.go
+++ b/ldclient.go
@@ -43,9 +43,9 @@ type Feature struct {
 }
 
 type TargetRule struct {
-	Attribute string   `json:"attribute"`
-	Op        Operator `json:"op"`
-	Values    []string `json:"values"`
+	Attribute string        `json:"attribute"`
+	Op        Operator      `json:"op"`
+	Values    []interface{} `json:"values"`
 }
 
 type Variation struct {
@@ -112,22 +112,21 @@ func matchCustom(target TargetRule, user User) bool {
 		return false
 	}
 
-	switch v.(type) {
-	case string:
-		return compareValues(v.(string), target.Values)
-	case []interface{}:
-		for _, cVal := range v.([]interface{}) {
-			if reflect.TypeOf(cVal).Kind() == reflect.String && compareValues(cVal.(string), target.Values) {
+	val := reflect.ValueOf(v)
+
+	if val.Kind() == reflect.Array || val.Kind() == reflect.Slice {
+		for i := 0; i < val.Len(); i++ {
+			if compareValues(val.Index(i).Interface(), target.Values) {
 				return true
 			}
 		}
-	default:
 		return false
+	} else {
+		return compareValues(v, target.Values)
 	}
-	return false
 }
 
-func compareValues(value string, values []string) bool {
+func compareValues(value interface{}, values []interface{}) bool {
 	if value == "" {
 		return false
 	} else {

--- a/ldclient_test.go
+++ b/ldclient_test.go
@@ -1,0 +1,152 @@
+package ldclient
+
+import (
+	"testing"
+)
+
+func TestTargetRuleWithBooleanValueMatches(t *testing.T) {
+	custom := make(map[string]interface{})
+	key := "test@test.com"
+
+	custom["member"] = true
+	user := User{
+		Key:    &key,
+		Custom: &custom,
+	}
+
+	rule := TargetRule{
+		Attribute: "member",
+		Op:        "in",
+		Values:    []interface{}{true},
+	}
+
+	if !matchCustom(rule, user) {
+		t.Errorf("Custom rule should match, but doesn't")
+	}
+}
+
+func TestTargetRuleWithIntValueMatches(t *testing.T) {
+	custom := make(map[string]interface{})
+	key := "test@test.com"
+
+	custom["customer_rank"] = 10000
+	user := User{
+		Key:    &key,
+		Custom: &custom,
+	}
+
+	rule := TargetRule{
+		Attribute: "customer_rank",
+		Op:        "in",
+		Values:    []interface{}{10000, 20000},
+	}
+
+	if !matchCustom(rule, user) {
+		t.Errorf("Custom rule should match, but doesn't")
+	}
+}
+
+func TestTargetRuleWithIntValueDoesNotMatch(t *testing.T) {
+	custom := make(map[string]interface{})
+	key := "test@test.com"
+
+	custom["customer_rank"] = 10000
+	user := User{
+		Key:    &key,
+		Custom: &custom,
+	}
+
+	rule := TargetRule{
+		Attribute: "customer_rank",
+		Op:        "in",
+		Values:    []interface{}{30000, 20000},
+	}
+
+	if matchCustom(rule, user) {
+		t.Errorf("Custom rule should not match, but does")
+	}
+}
+
+func TestTargetRuleWithStringValueMatches(t *testing.T) {
+	custom := make(map[string]interface{})
+	key := "test@test.com"
+
+	custom["group"] = "microsoft"
+	user := User{
+		Key:    &key,
+		Custom: &custom,
+	}
+
+	rule := TargetRule{
+		Attribute: "group",
+		Op:        "in",
+		Values:    []interface{}{"microsoft"},
+	}
+
+	if !matchCustom(rule, user) {
+		t.Errorf("Custom rule should match, but doesn't")
+	}
+}
+
+func TestTargetRuleWithStringValuesMatches(t *testing.T) {
+	custom := make(map[string]interface{})
+	key := "test@test.com"
+
+	custom["groups"] = []string{"microsoft", "google"}
+	user := User{
+		Key:    &key,
+		Custom: &custom,
+	}
+
+	rule := TargetRule{
+		Attribute: "groups",
+		Op:        "in",
+		Values:    []interface{}{"microsoft"},
+	}
+
+	if !matchCustom(rule, user) {
+		t.Errorf("Custom rule should match, but doesn't")
+	}
+}
+
+func TestTargetRuleWithStringArrayMatches(t *testing.T) {
+	custom := make(map[string]interface{})
+	key := "test@test.com"
+
+	custom["groups"] = [2]string{"microsoft", "google"}
+	user := User{
+		Key:    &key,
+		Custom: &custom,
+	}
+
+	rule := TargetRule{
+		Attribute: "groups",
+		Op:        "in",
+		Values:    []interface{}{"microsoft"},
+	}
+
+	if !matchCustom(rule, user) {
+		t.Errorf("Custom rule should match, but doesn't")
+	}
+}
+
+func TestTargetRuleWithHeterogenousArrayMatches(t *testing.T) {
+	custom := make(map[string]interface{})
+	key := "test@test.com"
+
+	custom["groups"] = [2]interface{}{3, "microsoft"}
+	user := User{
+		Key:    &key,
+		Custom: &custom,
+	}
+
+	rule := TargetRule{
+		Attribute: "groups",
+		Op:        "in",
+		Values:    []interface{}{"microsoft"},
+	}
+
+	if !matchCustom(rule, user) {
+		t.Errorf("Custom rule should match, but doesn't")
+	}
+}


### PR DESCRIPTION
This came from a customer request. I need to bump gonfalon and update the UI to support this. This is also useful in that it paves the way for real support for "op"
