### PR TITLE
Add an API method to check if the stream is disconnected, and add a config mode for LDD support

### DIFF
--- a/ldclient.go
+++ b/ldclient.go
@@ -355,6 +355,10 @@ func (client *LDClient) IsOffline() bool {
 	return client.offline
 }
 
+func (client *LDClient) IsStreamDisconnected() bool {
+	return client.config.Stream == false || client.streamProcessor == nil || client.streamProcessor.ShouldFallbackUpdate()
+}
+
 func (client *LDClient) Close() {
 	client.eventProcessor.close()
 }

--- a/ldclient.go
+++ b/ldclient.go
@@ -90,6 +90,7 @@ type Config struct {
 	Timeout       time.Duration
 	Stream        bool
 	FeatureStore  FeatureStore
+	UseLdd        bool
 }
 
 var DefaultConfig = Config{
@@ -101,6 +102,7 @@ var DefaultConfig = Config{
 	Timeout:       3000 * time.Millisecond,
 	Stream:        false,
 	FeatureStore:  nil,
+	UseLdd:        false,
 }
 
 func MakeCustomClient(apiKey string, config Config) LDClient {
@@ -436,11 +438,11 @@ func (client *LDClient) evaluate(key string, user User, defaultVal interface{}) 
 		return defaultVal, nil
 	}
 
-	if client.config.Stream && client.streamProcessor != nil && client.streamProcessor.Initialized() {
+	if client.IsStreamInitialized() {
 		var featurePtr *Feature
 		featurePtr, streamErr = client.streamProcessor.GetFeature(key)
 
-		if client.streamProcessor.ShouldFallbackUpdate() {
+		if !client.config.UseLdd && client.IsStreamDisconnected() {
 			go func() {
 				if feature, err := client.makeRequest(key); err != nil {
 					client.config.Logger.Printf("Failed to update feature in fallback mode. Flag values may be stale.")

--- a/ldclient.go
+++ b/ldclient.go
@@ -359,6 +359,10 @@ func (client *LDClient) IsStreamDisconnected() bool {
 	return client.config.Stream == false || client.streamProcessor == nil || client.streamProcessor.ShouldFallbackUpdate()
 }
 
+func (client *LDClient) IsStreamInitialized() bool {
+	return client.config.Stream && client.streamProcessor != nil && client.streamProcessor.Initialized()
+}
+
 func (client *LDClient) Close() {
 	client.eventProcessor.close()
 }

--- a/streaming.go
+++ b/streaming.go
@@ -72,9 +72,11 @@ func newStream(apiKey string, config Config) *StreamProcessor {
 		apiKey: apiKey,
 	}
 
-	go sp.Start()
+	if !config.UseLdd {
+		go sp.Start()
 
-	go sp.Errors()
+		go sp.Errors()
+	}
 
 	return sp
 }


### PR DESCRIPTION
This one grew a little bit in scope. The two new API methods I've exposed are there to be consumed by LDD, which needs a little more information about the state of the stream connection.

I've also added a new mode that essentially disables the SSE connection and relies on LDD to handle stream updates. This will only work if you have a Redis store configured, but right now I don't enforce that. If you try to set `UseLdd` and use an in-memory store, you'll fall back to polling because the stream processor will never be initialized