### PR TITLE
Fix potential goroutine leak

### DIFF
--- a/events.go
+++ b/events.go
@@ -108,14 +108,16 @@ func (ep *eventProcessor) flush() {
 
 	resp, respErr := ep.client.Do(req)
 
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
+		}
+	}()
+
 	if respErr != nil {
 		ep.config.Logger.Printf("Unexpected error while sending events: %+v", respErr)
 		return
-	}
-
-	if resp.Body != nil {
-		ioutil.ReadAll(resp.Body)
-		resp.Body.Close()
 	}
 
 }


### PR DESCRIPTION
When the server returns 5xx responses, we may have a goroutine leak.