### PR TITLE
Bump eventsource library

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -23,7 +23,7 @@
 		},
 		{
 			"ImportPath": "github.com/launchdarkly/eventsource",
-			"Rev": "e88deb7f4409208dc3d97cd1e7d990c3145f1ca3"
+			"Rev": "7a80b789e2ea45aa2f320c59203c306e8ded8f06"
 		},
 		{
 			"ImportPath": "github.com/patrickmn/go-cache",

--- a/Godeps/_workspace/src/github.com/launchdarkly/eventsource/codec_test.go
+++ b/Godeps/_workspace/src/github.com/launchdarkly/eventsource/codec_test.go
@@ -23,8 +23,8 @@ var encoderTests = []struct {
 
 func TestRoundTrip(t *testing.T) {
 	buf := new(bytes.Buffer)
-	enc := newEncoder(buf)
-	dec := newDecoder(buf)
+	enc := NewEncoder(buf, false)
+	dec := NewDecoder(buf)
 	for _, tt := range encoderTests {
 		want := tt.event
 		if err := enc.Encode(want); err != nil {

--- a/Godeps/_workspace/src/github.com/launchdarkly/eventsource/decoder.go
+++ b/Godeps/_workspace/src/github.com/launchdarkly/eventsource/decoder.go
@@ -17,12 +17,15 @@ func (s *publication) Event() string { return s.event }
 func (s *publication) Data() string  { return s.data }
 func (s *publication) Retry() int64  { return s.retry }
 
-type decoder struct {
+// A Decoder is capable of reading Events from a stream.
+type Decoder struct {
 	*bufio.Reader
 }
 
-func newDecoder(r io.Reader) *decoder {
-	dec := &decoder{bufio.NewReader(newNormaliser(r))}
+// NewDecoder returns a new Decoder instance that reads events
+// with the given io.Reader.
+func NewDecoder(r io.Reader) *Decoder {
+	dec := &Decoder{bufio.NewReader(newNormaliser(r))}
 	return dec
 }
 
@@ -31,7 +34,7 @@ func newDecoder(r io.Reader) *decoder {
 // Graceful disconnects (between events) are indicated by an io.EOF error.
 // Any error occuring mid-event is considered non-graceful and will
 // show up as some other error (most likely io.ErrUnexpectedEOF).
-func (dec *decoder) Decode() (Event, error) {
+func (dec *Decoder) Decode() (Event, error) {
 
 	// peek ahead before we start a new event so we can return EOFs
 	_, err := dec.Peek(1)

--- a/Godeps/_workspace/src/github.com/launchdarkly/eventsource/encoder.go
+++ b/Godeps/_workspace/src/github.com/launchdarkly/eventsource/encoder.go
@@ -1,6 +1,7 @@
 package eventsource
 
 import (
+	"compress/gzip"
 	"fmt"
 	"io"
 	"strings"
@@ -17,28 +18,41 @@ var (
 	}
 )
 
-type encoder struct {
-	w io.Writer
+// An Encoder is capable of writing Events to a stream. Optionally
+// Events can be gzip compressed in this process.
+type Encoder struct {
+	w          io.Writer
+	compressed bool
 }
 
-func newEncoder(w io.Writer) *encoder {
-	return &encoder{w: w}
+// NewEncoder returns an Encoder for a given io.Writer.
+// When compressed is set to true, a gzip writer will be
+// created.
+func NewEncoder(w io.Writer, compressed bool) *Encoder {
+	if compressed {
+		return &Encoder{w: gzip.NewWriter(w), compressed: true}
+	}
+	return &Encoder{w: w}
 }
 
-func (enc *encoder) Encode(ev Event) (err error) {
+// Encode writes an event in the format specified by the
+// server-sent events protocol.
+func (enc *Encoder) Encode(ev Event) error {
 	for _, field := range encFields {
 		prefix, value := field.prefix, field.value(ev)
 		if len(value) == 0 {
 			continue
 		}
 		value = strings.Replace(value, "\n", "\n"+prefix, -1)
-		if _, err = io.WriteString(enc.w, prefix+value+"\n"); err != nil {
-			err = fmt.Errorf("Eventsource: Encode: %s", err)
-			return
+		if _, err := io.WriteString(enc.w, prefix+value+"\n"); err != nil {
+			return fmt.Errorf("eventsource encode: %v", err)
 		}
 	}
-	if _, err = io.WriteString(enc.w, "\n"); err != nil {
-		err = fmt.Errorf("Eventsource: Encode: %s", err)
+	if _, err := io.WriteString(enc.w, "\n"); err != nil {
+		return fmt.Errorf("eventsource encode: %v", err)
 	}
-	return
+	if enc.compressed {
+		return enc.w.(*gzip.Writer).Flush()
+	}
+	return nil
 }

--- a/Godeps/_workspace/src/github.com/launchdarkly/eventsource/example_error_handling_stream_test.go
+++ b/Godeps/_workspace/src/github.com/launchdarkly/eventsource/example_error_handling_stream_test.go
@@ -2,7 +2,7 @@ package eventsource_test
 
 import (
 	"fmt"
-	"github.com/donovanhide/eventsource"
+	"github.com/launchdarkly/eventsource"
 	"net"
 	"net/http"
 )

--- a/Godeps/_workspace/src/github.com/launchdarkly/eventsource/example_event_test.go
+++ b/Godeps/_workspace/src/github.com/launchdarkly/eventsource/example_event_test.go
@@ -2,10 +2,11 @@ package eventsource_test
 
 import (
 	"fmt"
-	"github.com/donovanhide/eventsource"
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/launchdarkly/eventsource"
 )
 
 type TimeEvent time.Time
@@ -30,6 +31,7 @@ func TimePublisher(srv *eventsource.Server) {
 
 func ExampleEvent() {
 	srv := eventsource.NewServer()
+	srv.Gzip = true
 	defer srv.Close()
 	l, err := net.Listen("tcp", ":8080")
 	if err != nil {

--- a/Godeps/_workspace/src/github.com/launchdarkly/eventsource/example_repository_test.go
+++ b/Godeps/_workspace/src/github.com/launchdarkly/eventsource/example_repository_test.go
@@ -3,7 +3,7 @@ package eventsource_test
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/donovanhide/eventsource"
+	"github.com/launchdarkly/eventsource"
 	"net"
 	"net/http"
 )

--- a/streaming.go
+++ b/streaming.go
@@ -149,15 +149,15 @@ func (sp *streamProcessor) subscribe() {
 	defer sp.Unlock()
 
 	if sp.stream == nil {
-		headers := make(http.Header)
+		req, _ := http.NewRequest("GET", sp.config.StreamUri+"/features", nil)
+		req.Header.Add("Authorization", "api_key "+sp.apiKey)
+		req.Header.Add("User-Agent", "GoClient/"+Version)
 
-		headers.Add("Authorization", "api_key "+sp.apiKey)
-		headers.Add("User-Agent", "GoClient/"+Version)
-
-		if stream, err := es.Subscribe(sp.config.StreamUri+"/features", headers, ""); err != nil {
+		if stream, err := es.SubscribeWithRequest("", req); err != nil {
 			sp.config.Logger.Printf("Error subscribing to stream: %+v", err)
 		} else {
 			sp.stream = stream
+			sp.stream.Logger = sp.config.Logger
 		}
 	}
 }


### PR DESCRIPTION
This brings us even to master with the original upstream eventsource library. It offers us a more flexible pattern for setting up headers. It also lets us pass a logging configuration through, and sets us up to add a `Close()` method to the stream.