### PR TITLE
Bounded resource consumption refactoring

### DIFF
--- a/ldclient.go
+++ b/ldclient.go
@@ -106,6 +106,7 @@ func MakeCustomClient(apiKey string, config Config, waitFor time.Duration) (*LDC
 		config:          config,
 		eventProcessor:  newEventProcessor(apiKey, config),
 		updateProcessor: updateProcessor,
+		store:           store,
 	}
 
 	timeout := time.After(waitFor)

--- a/ldclient.go
+++ b/ldclient.go
@@ -63,8 +63,8 @@ var DefaultConfig = Config{
 	Offline:       false,
 }
 
-var InitializationTimeoutError = errors.New("Timeout encountered waiting for LaunchDarkly client initialization")
-var ClientNotInitializedError = errors.New("Toggle called before LaunchDarkly client initialization completed")
+var ErrInitializationTimeout = errors.New("Timeout encountered waiting for LaunchDarkly client initialization")
+var ErrClientNotInitialized = errors.New("Toggle called before LaunchDarkly client initialization completed")
 
 // Creates a new client instance that connects to LaunchDarkly with the default configuration. In most
 // cases, you should use this method to instantiate your client. The optional duration parameter allows callers to
@@ -117,10 +117,9 @@ func MakeCustomClient(apiKey string, config Config, waitFor time.Duration) (*LDC
 			return &client, nil
 		case <-timeout:
 			if waitFor > 0 {
-				return &client, InitializationTimeoutError
-			} else {
-				return &client, nil
+				return &client, ErrInitializationTimeout
 			}
+			return &client, nil
 		}
 	}
 }
@@ -264,7 +263,7 @@ func (client *LDClient) evaluate(key string, user User, defaultVal interface{}) 
 	var featurePtr *Feature
 
 	if !client.Initialized() {
-		return defaultVal, ClientNotInitializedError
+		return defaultVal, ErrClientNotInitialized
 	}
 
 	featurePtr, storeErr = client.store.Get(key)

--- a/ldclient.go
+++ b/ldclient.go
@@ -96,7 +96,7 @@ func MakeCustomClient(apiKey string, config Config, waitFor time.Duration) (*LDC
 		if config.Stream {
 			updateProcessor = newStreamProcessor(apiKey, config, store, requestor)
 		} else {
-			updateProcessor = newPollingProcessor(apiKey, config, store, requestor)
+			updateProcessor = newPollingProcessor(config, store, requestor)
 		}
 		updateProcessor.start(ch)
 	}

--- a/ldclient_test.go
+++ b/ldclient_test.go
@@ -13,16 +13,17 @@ var config = Config{
 	FlushInterval: 5 * time.Second,
 	Logger:        log.New(os.Stderr, "[LaunchDarkly]", log.LstdFlags),
 	Timeout:       1500 * time.Millisecond,
+	Stream:        true,
+	Offline:       true,
 }
 
 func TestOfflineModeAlwaysReturnsDefaultValue(t *testing.T) {
-	client := MakeCustomClient("api_key", config)
-	client.SetOffline()
+	client, _ := MakeCustomClient("api_key", config, 0)
 	var key = "foo"
 	res, err := client.Toggle("anything", User{Key: &key}, true)
 
 	if err != nil {
-		t.Errorf("Unexpected error in Toggle")
+		t.Errorf("Unexpected error in Toggle: %+v", err)
 	}
 
 	if !res {

--- a/polling.go
+++ b/polling.go
@@ -5,14 +5,15 @@ type pollingProcessor struct {
 
 // TODO
 func newPollingProcessor(apiKey string, config Config, store FeatureStore, requestor *requestor) updateProcessor {
-	return nil
+	panic("Can't get there from here")
 }
 
 // TODO
 func (pp *pollingProcessor) start(ch <-chan bool) {
+	panic("Can't get there from here")
 }
 
 // TODO
 func (pp *pollingProcessor) close() {
-
+	panic("Can't get there from here")
 }

--- a/polling.go
+++ b/polling.go
@@ -1,0 +1,18 @@
+package ldclient
+
+type pollingProcessor struct {
+}
+
+// TODO
+func newPollingProcessor(apiKey string, config Config, store FeatureStore, requestor *requestor) updateProcessor {
+	return nil
+}
+
+// TODO
+func (pp *pollingProcessor) start(ch <-chan bool) {
+}
+
+// TODO
+func (pp *pollingProcessor) close() {
+
+}

--- a/polling.go
+++ b/polling.go
@@ -62,6 +62,7 @@ func (pp *pollingProcessor) poll() error {
 	// update the store. Otherwise we'll have gotten a 304 (do nothing) or an
 	// error
 	if nextHdrs != nil {
+		pp.lastHeaders = nextHdrs
 		return pp.store.Init(features)
 	}
 	return nil

--- a/polling.go
+++ b/polling.go
@@ -1,19 +1,70 @@
 package ldclient
 
+import (
+	"sync"
+	"time"
+)
+
 type pollingProcessor struct {
+	store              FeatureStore
+	requestor          *requestor
+	config             Config
+	setInitializedOnce sync.Once
+	isInitialized      bool
+	lastHeaders        *cacheHeaders
 }
 
-// TODO
-func newPollingProcessor(apiKey string, config Config, store FeatureStore, requestor *requestor) updateProcessor {
-	panic("Can't get there from here")
+func newPollingProcessor(config Config, store FeatureStore, requestor *requestor) updateProcessor {
+	pp := &pollingProcessor{
+		store:     store,
+		requestor: requestor,
+		config:    config,
+	}
+
+	return pp
 }
 
-// TODO
-func (pp *pollingProcessor) start(ch <-chan bool) {
-	panic("Can't get there from here")
+func (pp *pollingProcessor) start(ch chan<- bool) {
+	go func() {
+		for {
+			then := time.Now()
+			err := pp.poll()
+			if err == nil {
+				pp.setInitializedOnce.Do(func() {
+					pp.isInitialized = true
+					ch <- true
+				})
+			}
+			delta := (1 * time.Second) - time.Since(then)
+
+			if delta > 0 {
+				time.Sleep(delta)
+			}
+		}
+	}()
 }
 
-// TODO
+func (pp *pollingProcessor) poll() error {
+	features, nextHdrs, err := pp.requestor.makeAllRequest(pp.lastHeaders, true)
+
+	if err != nil {
+		return err
+	}
+
+	// We get nextHdrs only if we got a 200 response, which means we need to
+	// update the store. Otherwise we'll have gotten a 304 (do nothing) or an
+	// error
+	if nextHdrs != nil {
+		return pp.store.Init(features)
+	}
+	return nil
+}
+
+// TODO add support for canceling the goroutine
 func (pp *pollingProcessor) close() {
-	panic("Can't get there from here")
+
+}
+
+func (pp *pollingProcessor) initialized() bool {
+	return pp.isInitialized
 }

--- a/polling.go
+++ b/polling.go
@@ -15,9 +15,9 @@ type pollingProcessor struct {
 	quit               chan bool
 }
 
-func newPollingProcessor(config Config, store FeatureStore, requestor *requestor) updateProcessor {
+func newPollingProcessor(config Config, requestor *requestor) updateProcessor {
 	pp := &pollingProcessor{
-		store:     store,
+		store:     config.FeatureStore,
 		requestor: requestor,
 		config:    config,
 		quit:      make(chan bool),
@@ -41,7 +41,7 @@ func (pp *pollingProcessor) start(ch chan<- bool) {
 						ch <- true
 					})
 				}
-				delta := (1 * time.Second) - time.Since(then)
+				delta := pp.config.PollInterval - time.Since(then)
 
 				if delta > 0 {
 					time.Sleep(delta)

--- a/requestor.go
+++ b/requestor.go
@@ -3,7 +3,6 @@ package ldclient
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"github.com/facebookgo/httpcontrol"
 	"github.com/gregjones/httpcache"
 	"io/ioutil"

--- a/streaming.go
+++ b/streaming.go
@@ -84,7 +84,7 @@ func (sp *streamProcessor) startOnce(ch chan<- bool) {
 				sp.store.Upsert(key, *feature)
 			}
 		case indirectPutEvent:
-			if features, _, err := sp.requestor.makeAllRequest(nil, true); err != nil {
+			if features, _, err := sp.requestor.makeAllRequest(true); err != nil {
 				sp.config.Logger.Printf("Unexpected error requesting all features: %+v", err)
 			} else {
 				sp.store.Init(features)

--- a/streaming.go
+++ b/streaming.go
@@ -2,7 +2,6 @@ package ldclient
 
 import (
 	"encoding/json"
-	"errors"
 	es "github.com/launchdarkly/eventsource"
 	"io"
 	"net/http"
@@ -20,13 +19,13 @@ const (
 )
 
 type streamProcessor struct {
-	store        FeatureStore
-	requestor    *requestor
-	stream       *es.Stream
-	config       Config
-	disconnected *time.Time
-	apiKey       string
-	ignition     sync.Once
+	store              FeatureStore
+	requestor          *requestor
+	stream             *es.Stream
+	config             Config
+	apiKey             string
+	setInitializedOnce sync.Once
+	isInitialized      bool
 	sync.RWMutex
 }
 
@@ -40,38 +39,19 @@ type featureDeleteData struct {
 	Version int    `json:"version"`
 }
 
-func (sp *streamProcessor) Initialized() bool {
-	return sp.store.Initialized()
+func (sp *streamProcessor) initialized() bool {
+	return sp.isInitialized
 }
 
-func (sp *streamProcessor) GetFeature(key string) (*Feature, error) {
-	if !sp.store.Initialized() {
-		return nil, errors.New("Requested stream data before initialization completed")
-	} else {
-		return sp.store.Get(key)
-	}
+func (sp *streamProcessor) start(ch chan<- bool) {
+	go sp.startOnce(ch)
+	go sp.errors()
 }
 
-func (sp *streamProcessor) ShouldFallbackUpdate() bool {
-	sp.RLock()
-	defer sp.RUnlock()
-	return sp.disconnected != nil && sp.disconnected.Before(time.Now().Add(-2*time.Minute))
-}
-
-func (sp *streamProcessor) StartOnce() {
-	sp.ignition.Do(func() {
-		if !sp.config.UseLdd {
-			go sp.start()
-			go sp.errors()
-		}
-	})
-}
-
-func (sp *streamProcessor) start() {
+func (sp *streamProcessor) startOnce(ch chan<- bool) {
 	for {
 		subscribed := sp.checkSubscribe()
 		if !subscribed {
-			sp.setDisconnected()
 			time.Sleep(2 * time.Second)
 			continue
 		}
@@ -83,7 +63,10 @@ func (sp *streamProcessor) start() {
 				sp.config.Logger.Printf("Unexpected error unmarshalling feature json: %+v", err)
 			} else {
 				sp.store.Init(features)
-				sp.setConnected()
+				sp.setInitializedOnce.Do(func() {
+					sp.isInitialized = true
+					ch <- true
+				})
 			}
 		case patchEvent:
 			var patch featurePatchData
@@ -92,7 +75,6 @@ func (sp *streamProcessor) start() {
 			} else {
 				key := strings.TrimLeft(patch.Path, "/")
 				sp.store.Upsert(key, patch.Data)
-				sp.setConnected()
 			}
 		case indirectPatchEvent:
 			key := event.Data()
@@ -100,14 +82,15 @@ func (sp *streamProcessor) start() {
 				sp.config.Logger.Printf("Unexpected error requesting feature: %+v", err)
 			} else {
 				sp.store.Upsert(key, *feature)
-				sp.setConnected()
 			}
 		case indirectPutEvent:
 			if features, err := sp.requestor.makeAllRequest(true); err != nil {
 				sp.config.Logger.Printf("Unexpected error requesting all features: %+v", err)
 			} else {
 				sp.store.Init(features)
-				sp.setConnected()
+				sp.setInitializedOnce.Do(func() {
+					sp.isInitialized = true
+				})
 			}
 		case deleteEvent:
 			var data featureDeleteData
@@ -116,24 +99,14 @@ func (sp *streamProcessor) start() {
 			} else {
 				key := strings.TrimLeft(data.Path, "/")
 				sp.store.Delete(key, data.Version)
-				sp.setConnected()
 			}
 		default:
 			sp.config.Logger.Printf("Unexpected event found in stream: %s", event.Event())
-			sp.setConnected()
 		}
 	}
 }
 
-func newStream(apiKey string, config Config, requestor *requestor) *streamProcessor {
-	var store FeatureStore
-
-	if config.FeatureStore != nil {
-		store = config.FeatureStore
-	} else {
-		store = NewInMemoryFeatureStore()
-	}
-
+func newStreamProcessor(apiKey string, config Config, store FeatureStore, requestor *requestor) updateProcessor {
 	sp := &streamProcessor{
 		store:     store,
 		config:    config,
@@ -178,7 +151,6 @@ func (sp *streamProcessor) errors() {
 	for {
 		subscribed := sp.checkSubscribe()
 		if !subscribed {
-			sp.setDisconnected()
 			time.Sleep(2 * time.Second)
 			continue
 		}
@@ -188,37 +160,11 @@ func (sp *streamProcessor) errors() {
 			sp.config.Logger.Printf("Error encountered processing stream: %+v", err)
 		}
 		if err != nil {
-			sp.setDisconnected()
 		}
 	}
 }
 
-func (sp *streamProcessor) setConnected() {
-	sp.RLock()
-	if sp.disconnected != nil {
-		sp.RUnlock()
-		sp.Lock()
-		defer sp.Unlock()
-		if sp.disconnected != nil {
-			sp.disconnected = nil
-		}
-	} else {
-		sp.RUnlock()
-	}
-
-}
-
-func (sp *streamProcessor) setDisconnected() {
-	sp.RLock()
-	if sp.disconnected == nil {
-		sp.RUnlock()
-		sp.Lock()
-		defer sp.Unlock()
-		if sp.disconnected == nil {
-			now := time.Now()
-			sp.disconnected = &now
-		}
-	} else {
-		sp.RUnlock()
-	}
+func (sp *streamProcessor) close() {
+	// TODO : the EventSource library doesn't support close() yet.
+	// when it does, call it here
 }

--- a/streaming.go
+++ b/streaming.go
@@ -84,7 +84,7 @@ func (sp *streamProcessor) startOnce(ch chan<- bool) {
 				sp.store.Upsert(key, *feature)
 			}
 		case indirectPutEvent:
-			if features, err := sp.requestor.makeAllRequest(true); err != nil {
+			if features, _, err := sp.requestor.makeAllRequest(nil, true); err != nil {
 				sp.config.Logger.Printf("Unexpected error requesting all features: %+v", err)
 			} else {
 				sp.store.Init(features)

--- a/streaming.go
+++ b/streaming.go
@@ -106,9 +106,9 @@ func (sp *streamProcessor) startOnce(ch chan<- bool) {
 	}
 }
 
-func newStreamProcessor(apiKey string, config Config, store FeatureStore, requestor *requestor) updateProcessor {
+func newStreamProcessor(apiKey string, config Config, requestor *requestor) updateProcessor {
 	sp := &streamProcessor{
-		store:     store,
+		store:     config.FeatureStore,
 		config:    config,
 		apiKey:    apiKey,
 		requestor: requestor,


### PR DESCRIPTION
This is my proposed approach to bounding resource consumption in the go client. I also think this should be the reference model for all SDKs (save PHP and to a certain degree mobile) going forward. There are a number of ideas in here:

* We're going to completely ditch the polling-for-a-single-feature model
* There's a new `updateProcessor` abstraction, so we're more cleanly separating the process of updating the feature store from reading the feature store
* We're replacing the polling-for-a-single-feature model with a poll-for-all-features model . This will be the backup option if streaming is disabled, and it is handled as a separate `updateProcessor` implementation
* For simplicity right now, we ditch the attempt to fall back to polling if the stream is disconnected. It would be slick to dynamically switch back and forth between streaming and polling, but the state management is significantly more complex and the EventSource implementation doesn't support such transitions yet
* Clients can choose whether to block on client initialization, with a configurable timeout
* We no longer do lazy stream initialization. Instead, you have to decide whether or not your client should be offline in your config, and you can't dynamically change that.
* The store is now accessed directly by the `LDClient`, and we no longer ask it whether it's initialized. This is potentially a big performance win because we no longer make a remote redis call to check initialization on every toggle call.

There's probably more here, so it's worth going over this in person as a group. But here is the first cut of it for early feedback.