### PR TITLE
Fall through to the off variation (not the default variation) if evaluation returns nil

### DIFF
--- a/ldclient.go
+++ b/ldclient.go
@@ -310,7 +310,7 @@ func (client *LDClient) Evaluate(key string, user User, defaultVal interface{}) 
 		if evalResult.Value != nil {
 			return evalResult.Value, nil
 		}
-		return defaultVal, nil
+		// If the value is nil, but the error is not, fall through and use the off variation
 	}
 
 	if feature.OffVariation != nil && *feature.OffVariation < len(feature.Variations) {


### PR DESCRIPTION
This further codifies the idea that the default variation is only used in specific circumstances:

* The user or user key does not exist
* The client has not been bootstrapped properly
* The feature key does not exist in the store, or the store returned an error
* There is no off variation defined, or the off variation is invalid