### PR TITLE
Don't block update processing when no init timeout is set

### DIFF
--- a/ldclient.go
+++ b/ldclient.go
@@ -134,6 +134,8 @@ func MakeCustomClient(sdkKey string, config Config, waitFor time.Duration) (*LDC
 				config.Logger.Println("Timeout exceeded when initializing LauncDarkly client.")
 				return &client, ErrInitializationTimeout
 			}
+
+			go func() { <-ch }() // Don't block the updateProcessor when not waiting
 			return &client, nil
 		}
 	}


### PR DESCRIPTION
If no initialization timeout value was set, the update processor init
channel was never read, blocking the update processor indefinitely. Read
from the channel so the update processor can actually process updates ;)