### PR TITLE
Use a generic logger implementation

### DIFF
--- a/feature_store.go
+++ b/feature_store.go
@@ -4,6 +4,8 @@ import (
 	"log"
 	"os"
 	"sync"
+
+	es "github.com/launchdarkly/eventsource"
 )
 
 // A data structure that maintains the live
@@ -27,11 +29,11 @@ type InMemoryFeatureStore struct {
 	features      map[string]*FeatureFlag
 	isInitialized bool
 	sync.RWMutex
-	logger Logger
+	logger es.Logger
 }
 
 // Creates a new in-memory FeatureStore instance.
-func NewInMemoryFeatureStore(logger Logger) *InMemoryFeatureStore {
+func NewInMemoryFeatureStore(logger es.Logger) *InMemoryFeatureStore {
 	if logger == nil {
 		logger = log.New(os.Stderr, "[LaunchDarkly InMemoryFeatureStore]", log.LstdFlags)
 	}

--- a/feature_store.go
+++ b/feature_store.go
@@ -27,11 +27,11 @@ type InMemoryFeatureStore struct {
 	features      map[string]*FeatureFlag
 	isInitialized bool
 	sync.RWMutex
-	logger *log.Logger
+	logger Logger
 }
 
 // Creates a new in-memory FeatureStore instance.
-func NewInMemoryFeatureStore(logger *log.Logger) *InMemoryFeatureStore {
+func NewInMemoryFeatureStore(logger Logger) *InMemoryFeatureStore {
 	if logger == nil {
 		logger = log.New(os.Stderr, "[LaunchDarkly InMemoryFeatureStore]", log.LstdFlags)
 	}

--- a/ldclient.go
+++ b/ldclient.go
@@ -12,6 +12,8 @@ import (
 	"reflect"
 	"strings"
 	"time"
+
+	es "github.com/launchdarkly/eventsource"
 )
 
 const Version string = "2.0.0"
@@ -36,18 +38,13 @@ type Config struct {
 	FlushInterval    time.Duration
 	SamplingInterval int32
 	PollInterval     time.Duration
-	Logger           Logger
+	Logger           es.Logger
 	Timeout          time.Duration
 	Stream           bool
 	FeatureStore     FeatureStore
 	UseLdd           bool
 	SendEvents       bool
 	Offline          bool
-}
-
-type Logger interface {
-	Println(...interface{})
-	Printf(string, ...interface{})
 }
 
 type updateProcessor interface {

--- a/redis.go
+++ b/redis.go
@@ -3,12 +3,15 @@ package ldclient
 import (
 	"encoding/json"
 	"fmt"
-	r "github.com/garyburd/redigo/redis"
-	"github.com/patrickmn/go-cache"
 	"log"
 	"os"
-	"time"
 	"reflect"
+	"time"
+
+	r "github.com/garyburd/redigo/redis"
+	"github.com/patrickmn/go-cache"
+
+	es "github.com/launchdarkly/eventsource"
 )
 
 // A Redis-backed feature store.
@@ -17,7 +20,7 @@ type RedisFeatureStore struct {
 	pool    *r.Pool
 	cache   *cache.Cache
 	timeout time.Duration
-	logger  Logger
+	logger  es.Logger
 }
 
 const (
@@ -56,7 +59,7 @@ func (store *RedisFeatureStore) getConn() r.Conn {
 // connection pool configuration (16 concurrent connections, connection requests block).
 // Attaches a prefix string to all keys to namespace LaunchDarkly-specific keys. If the
 // specified prefix is the empty string, it defaults to "launchdarkly".
-func NewRedisFeatureStoreFromUrl(url, prefix string, timeout time.Duration, logger Logger) *RedisFeatureStore {
+func NewRedisFeatureStoreFromUrl(url, prefix string, timeout time.Duration, logger es.Logger) *RedisFeatureStore {
 	if logger == nil {
 		logger = defaultLogger()
 	}
@@ -68,7 +71,7 @@ func NewRedisFeatureStoreFromUrl(url, prefix string, timeout time.Duration, logg
 // Constructs a new Redis-backed feature store with the specified redigo pool configuration.
 // Attaches a prefix string to all keys to namespace LaunchDarkly-specific keys. If the
 // specified prefix is the empty string, it defaults to "launchdarkly".
-func NewRedisFeatureStoreWithPool(pool *r.Pool, prefix string, timeout time.Duration, logger Logger) *RedisFeatureStore {
+func NewRedisFeatureStoreWithPool(pool *r.Pool, prefix string, timeout time.Duration, logger es.Logger) *RedisFeatureStore {
 	var c *cache.Cache
 
 	if logger == nil {
@@ -99,7 +102,7 @@ func NewRedisFeatureStoreWithPool(pool *r.Pool, prefix string, timeout time.Dura
 // connection pool configuration (16 concurrent connections, connection requests block).
 // Attaches a prefix string to all keys to namespace LaunchDarkly-specific keys. If the
 // specified prefix is the empty string, it defaults to "launchdarkly"
-func NewRedisFeatureStore(host string, port int, prefix string, timeout time.Duration, logger Logger) *RedisFeatureStore {
+func NewRedisFeatureStore(host string, port int, prefix string, timeout time.Duration, logger es.Logger) *RedisFeatureStore {
 	return NewRedisFeatureStoreFromUrl(fmt.Sprintf("redis://%s:%d", host, port), prefix, timeout, logger)
 }
 

--- a/redis.go
+++ b/redis.go
@@ -17,7 +17,7 @@ type RedisFeatureStore struct {
 	pool    *r.Pool
 	cache   *cache.Cache
 	timeout time.Duration
-	logger  *log.Logger
+	logger  Logger
 }
 
 const (
@@ -56,7 +56,7 @@ func (store *RedisFeatureStore) getConn() r.Conn {
 // connection pool configuration (16 concurrent connections, connection requests block).
 // Attaches a prefix string to all keys to namespace LaunchDarkly-specific keys. If the
 // specified prefix is the empty string, it defaults to "launchdarkly".
-func NewRedisFeatureStoreFromUrl(url, prefix string, timeout time.Duration, logger *log.Logger) *RedisFeatureStore {
+func NewRedisFeatureStoreFromUrl(url, prefix string, timeout time.Duration, logger Logger) *RedisFeatureStore {
 	if logger == nil {
 		logger = defaultLogger()
 	}
@@ -68,7 +68,7 @@ func NewRedisFeatureStoreFromUrl(url, prefix string, timeout time.Duration, logg
 // Constructs a new Redis-backed feature store with the specified redigo pool configuration.
 // Attaches a prefix string to all keys to namespace LaunchDarkly-specific keys. If the
 // specified prefix is the empty string, it defaults to "launchdarkly".
-func NewRedisFeatureStoreWithPool(pool *r.Pool, prefix string, timeout time.Duration, logger *log.Logger) *RedisFeatureStore {
+func NewRedisFeatureStoreWithPool(pool *r.Pool, prefix string, timeout time.Duration, logger Logger) *RedisFeatureStore {
 	var c *cache.Cache
 
 	if logger == nil {
@@ -99,7 +99,7 @@ func NewRedisFeatureStoreWithPool(pool *r.Pool, prefix string, timeout time.Dura
 // connection pool configuration (16 concurrent connections, connection requests block).
 // Attaches a prefix string to all keys to namespace LaunchDarkly-specific keys. If the
 // specified prefix is the empty string, it defaults to "launchdarkly"
-func NewRedisFeatureStore(host string, port int, prefix string, timeout time.Duration, logger *log.Logger) *RedisFeatureStore {
+func NewRedisFeatureStore(host string, port int, prefix string, timeout time.Duration, logger Logger) *RedisFeatureStore {
 	return NewRedisFeatureStoreFromUrl(fmt.Sprintf("redis://%s:%d", host, port), prefix, timeout, logger)
 }
 
@@ -306,6 +306,6 @@ func (store *RedisFeatureStore) Initialized() bool {
 	return err == nil && init
 }
 
-func defaultLogger() *log.Logger {
+func defaultLogger() Logger {
 	return log.New(os.Stderr, "[LaunchDarkly]", log.LstdFlags)
 }

--- a/streaming.go
+++ b/streaming.go
@@ -2,12 +2,13 @@ package ldclient
 
 import (
 	"encoding/json"
-	es "github.com/launchdarkly/eventsource"
 	"io"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
+
+	es "github.com/launchdarkly/eventsource"
 )
 
 const (
@@ -135,7 +136,8 @@ func (sp *streamProcessor) subscribe() {
 			sp.config.Logger.Printf("Error subscribing to stream: %+v using URL: %s", err, req.URL.String())
 		} else {
 			sp.stream = stream
-			sp.stream.Logger = sp.config.Logger
+			//TODO: handle steam.Logger
+			//sp.stream.Logger = sp.config.Logger
 		}
 	}
 }

--- a/streaming.go
+++ b/streaming.go
@@ -136,8 +136,7 @@ func (sp *streamProcessor) subscribe() {
 			sp.config.Logger.Printf("Error subscribing to stream: %+v using URL: %s", err, req.URL.String())
 		} else {
 			sp.stream = stream
-			//TODO: handle steam.Logger
-			//sp.stream.Logger = sp.config.Logger
+			sp.stream.Logger = sp.config.Logger
 		}
 	}
 }


### PR DESCRIPTION
https://github.com/launchdarkly/eventsource/pull/5

Seems like you only use `Config.logger` for `logger.Println` and `logger.Printf`. If that's the case, I think it would be really useful to be able to provide a custom implementation of a `Logger` to `ldclient.Config` so we can use our own custom loggers which are standardized across our application.