### PR TITLE
Use generic logger interface

### DIFF
--- a/vendor/github.com/launchdarkly/eventsource/interface.go
+++ b/vendor/github.com/launchdarkly/eventsource/interface.go
@@ -23,3 +23,8 @@ type Repository interface {
 	// Gets the Events which should follow on from the specified channel and event id.
 	Replay(channel, id string) chan Event
 }
+
+type Logger interface {
+	Println(...interface{})
+	Printf(string, ...interface{})
+}

--- a/vendor/github.com/launchdarkly/eventsource/server.go
+++ b/vendor/github.com/launchdarkly/eventsource/server.go
@@ -1,7 +1,6 @@
 package eventsource
 
 import (
-	"log"
 	"net/http"
 	"strings"
 )
@@ -22,11 +21,11 @@ type registration struct {
 }
 
 type Server struct {
-	AllowCORS     bool        // Enable all handlers to be accessible from any origin
-	ReplayAll     bool        // Replay repository even if there's no Last-Event-Id specified
-	BufferSize    int         // How many messages do we let the client get behind before disconnecting
-	Gzip          bool        // Enable compression if client can accept it
-	Logger        *log.Logger // Logger is a logger that, when set, will be used for logging debug messages
+	AllowCORS     bool   // Enable all handlers to be accessible from any origin
+	ReplayAll     bool   // Replay repository even if there's no Last-Event-Id specified
+	BufferSize    int    // How many messages do we let the client get behind before disconnecting
+	Gzip          bool   // Enable compression if client can accept it
+	Logger        Logger // Logger is a logger that, when set, will be used for logging debug messages
 	registrations chan *registration
 	pub           chan *outbound
 	subs          chan *subscription

--- a/vendor/github.com/launchdarkly/eventsource/stream.go
+++ b/vendor/github.com/launchdarkly/eventsource/stream.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"time"
 )
@@ -26,7 +25,7 @@ type Stream struct {
 	// even if that involves reconnecting to the server.
 	Errors chan error
 	// Logger is a logger that, when set, will be used for logging debug messages
-	Logger *log.Logger
+	Logger Logger
 }
 
 type SubscriptionError struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -43,9 +43,10 @@
 			"revision": "d02018f006d98f58512bf3adfc171d88d17626df"
 		},
 		{
-			"checksumSHA1": "sZ1ADTK3Y1AuvR2BDs1QTJFz3wY=",
+			"checksumSHA1": "hNJyOkzYgQxH+tjGQNVFkxk0Hjg=",
 			"path": "github.com/launchdarkly/eventsource",
-			"revision": "7a80b789e2ea45aa2f320c59203c306e8ded8f06"
+			"revision": "a45c212c667804d2687d2780839b04e288e2160d",
+			"revisionTime": "2017-12-20T01:50:56Z"
 		},
 		{
 			"checksumSHA1": "vNL7xL08iaySNAxSUz+AoXGu3DQ=",
@@ -64,5 +65,5 @@
 			"revision": "6fe211e493929a8aac0469b93f28b1d0688a9a3a"
 		}
 	],
-	"rootPath": "github.com/launchdarkly/go-client-private"
+	"rootPath": "github.com/launchdarkly/go-client"
 }


### PR DESCRIPTION
Allows for loggers other than the standard go logger.

Based on the suggestion by @ZiaoGoergeJiang in https://github.com/launchdarkly/go-client/pull/106.  This version includes vendored files and defines the logger interface explicitly rather than getting it from eventsource.