### PR TITLE
Auto-format source tree

### DIFF
--- a/events.go
+++ b/events.go
@@ -152,7 +152,7 @@ func (ep *eventProcessor) sendEvent(evt Event) error {
 		return nil
 	}
 
-	scrubbedUser := scrubUser(evt.GetBase().User, ep.config.AllAttributesPrivate, ep.config.PrivateAttributeNames) 	
+	scrubbedUser := scrubUser(evt.GetBase().User, ep.config.AllAttributesPrivate, ep.config.PrivateAttributeNames)
 	var newEvent Event
 	switch evt := evt.(type) {
 	case FeatureRequestEvent:
@@ -175,8 +175,8 @@ func (ep *eventProcessor) sendEvent(evt Event) error {
 		return nil
 	}
 	if len(ep.queue) >= ep.config.Capacity {
- 		return errors.New("Exceeded event queue capacity. Increase capacity to avoid dropping events.")
- 	}
+		return errors.New("Exceeded event queue capacity. Increase capacity to avoid dropping events.")
+	}
 	ep.queue = append(ep.queue, newEvent)
 	return nil
 }

--- a/flag.go
+++ b/flag.go
@@ -41,8 +41,8 @@ func (f *FeatureFlag) IsDeleted() bool {
 }
 
 func (f *FeatureFlag) Clone() VersionedData {
-	f1 := *f;
-	return &f1;
+	f1 := *f
+	return &f1
 }
 
 type FeatureFlagVersionedDataKind struct{}

--- a/operators_test.go
+++ b/operators_test.go
@@ -15,11 +15,12 @@ const invalidDate = "hey what's this?"
 
 type opTestInfo struct {
 	opName      Operator
-	userValue      interface{}
-	clauseValue      interface{}
+	userValue   interface{}
+	clauseValue interface{}
 	expected    bool
 }
-var operatorTests = []opTestInfo {
+
+var operatorTests = []opTestInfo{
 	// numeric operators
 	{"in", int(99), int(99), true},
 	{"in", float64(99.0001), float64(99.0001), true},

--- a/segment.go
+++ b/segment.go
@@ -23,8 +23,8 @@ func (s *Segment) IsDeleted() bool {
 }
 
 func (s *Segment) Clone() VersionedData {
-	s1 := *s;
-	return &s1;
+	s1 := *s
+	return &s1
 }
 
 type SegmentVersionedDataKind struct{}

--- a/util_test.go
+++ b/util_test.go
@@ -107,7 +107,7 @@ func TestToJsonRawMessage(t *testing.T) {
 	expectedJsonString := `{"FieldName":"fieldValue","NumericField":1.02}`
 
 	type expected struct {
-		FieldName string  `json:"FieldName"`
+		FieldName    string  `json:"FieldName"`
 		NumericField float64 `json:"NumericField"`
 	}
 	expectedStruct := expected{FieldName: "fieldValue", NumericField: 1.02}
@@ -128,4 +128,3 @@ func TestToJsonRawMessage(t *testing.T) {
 		}
 	}
 }
-


### PR DESCRIPTION
Using `go fmt ./...`.

I noticed that some files aren't formatted properly.