### PR TITLE
Conform to io.Closer interface

### DIFF
--- a/ldclient.go
+++ b/ldclient.go
@@ -203,15 +203,16 @@ func (client *LDClient) Initialized() bool {
 
 // Shuts down the LaunchDarkly client. After calling this, the LaunchDarkly client
 // should no longer be used.
-func (client *LDClient) Close() {
+func (client *LDClient) Close() error {
 	client.config.Logger.Println("Closing LaunchDarkly Client")
 	if client.IsOffline() {
-		return
+		return nil
 	}
 	client.eventProcessor.close()
 	if !client.config.UseLdd {
 		client.updateProcessor.Close()
 	}
+	return nil
 }
 
 // Immediately flushes queued events.

--- a/ldclient_test.go
+++ b/ldclient_test.go
@@ -3,6 +3,7 @@ package ldclient
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"testing"
@@ -25,8 +26,10 @@ func TestOfflineModeAlwaysReturnsDefaultValue(t *testing.T) {
 		Stream:        true,
 		Offline:       true,
 	}
+	var closer io.Closer
 	client, _ := MakeCustomClient("api_key", config, 0)
-	defer client.Close()
+	closer = client
+	defer closer.Close()
 	client.config.Offline = true
 	key := "foo"
 	user := User{Key: &key}


### PR DESCRIPTION
This allows consumers to aggregate the `LDClient` with whatever other `io.Closer`s they need to poke at shutdown.