### PR TITLE
Provide list of supported VersionedDataKind's

### DIFF
--- a/versioned_data.go
+++ b/versioned_data.go
@@ -19,3 +19,10 @@ type VersionedDataKind interface {
 	// Return a value of this object type with the specified key and version, and Deleted=true.
 	MakeDeletedItem(key string, version int) VersionedData
 }
+
+// A list of supported VersionedDataKind's. Among other things, this list might
+// be used by feature stores to know what data (namespaces) to expect.
+var VersionedDataKinds = [...]VersionedDataKind{
+	Features,
+	Segments,
+}


### PR DESCRIPTION
In order to tell feature stores what data to expect.

As mentioned in another PR, I'm currently working on a DynamoDB-backed feature store. While development, I've noticed that there's currently no direct way for the store to know at compile time what kind of data to persist. This makes it difficult to, for example, check that there's DynamoDB table for feature flags or another one for segments before consuming any data from the API at runtime.