### PR TITLE
prepare 4.2.0 release

### DIFF
--- a/polling.go
+++ b/polling.go
@@ -51,8 +51,8 @@ func (pp *pollingProcessor) Start(closeWhenReady chan<- struct{}) {
 				if err := pp.poll(); err != nil {
 					pp.config.Logger.Printf("ERROR: Error when requesting feature updates: %+v", err)
 					if hse, ok := err.(*HttpStatusError); ok {
-						if hse.Code == 401 {
-							pp.config.Logger.Printf("ERROR: Received 401 error, no further polling requests will be made since SDK key is invalid")
+						pp.config.Logger.Printf("ERROR: %s", httpErrorMessage(hse.Code, "polling request", "will retry"))
+						if !isHTTPErrorRecoverable(hse.Code) {
 							notifyReady()
 							return
 						}

--- a/streaming.go
+++ b/streaming.go
@@ -215,7 +215,6 @@ func (sp *streamProcessor) subscribe(closeWhenReady chan<- struct{}) {
 		sp.config.Logger.Printf("Connecting to LaunchDarkly stream using URL: %s", req.URL.String())
 
 		if stream, err := es.SubscribeWithRequest("", req); err != nil {
-			sp.config.Logger.Printf("*** error: %+v\n", err)
 			if sp.checkIfPermanentFailure(err) {
 				close(closeWhenReady)
 				return
@@ -230,7 +229,6 @@ func (sp *streamProcessor) subscribe(closeWhenReady chan<- struct{}) {
 				time.Sleep(2 * time.Second)
 			}
 		} else {
-			sp.config.Logger.Println("*** success")
 			sp.stream = stream
 			sp.stream.Logger = sp.config.Logger
 

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -30,160 +30,160 @@ func (r *testRepo) Replay(channel, id string) chan eventsource.Event {
 	return c
 }
 
-// func runStreamingTest(t *testing.T, initialEvent eventsource.Event, test func(events chan<- eventsource.Event, store FeatureStore)) {
-// 	esserver := eventsource.NewServer()
-// 	esserver.ReplayAll = true
-// 	esserver.Register("test", &testRepo{initialEvent: initialEvent})
-// 	events := make(chan eventsource.Event, 1000)
-// 	streamServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-// 		assert.Equal(t, "/all", r.URL.Path)
-// 		go func() {
-// 			for e := range events {
-// 				esserver.Publish([]string{"test"}, e)
-// 			}
-// 		}()
-// 		esserver.Handler("test").ServeHTTP(w, r)
-// 	}))
-// 	defer streamServer.Close()
+func runStreamingTest(t *testing.T, initialEvent eventsource.Event, test func(events chan<- eventsource.Event, store FeatureStore)) {
+	esserver := eventsource.NewServer()
+	esserver.ReplayAll = true
+	esserver.Register("test", &testRepo{initialEvent: initialEvent})
+	events := make(chan eventsource.Event, 1000)
+	streamServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/all", r.URL.Path)
+		go func() {
+			for e := range events {
+				esserver.Publish([]string{"test"}, e)
+			}
+		}()
+		esserver.Handler("test").ServeHTTP(w, r)
+	}))
+	defer streamServer.Close()
 
-// 	sdkServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-// 		assert.Equal(t, "/sdk/latest-flags/my-flag", r.URL.Path)
-// 		w.Write([]byte(`{"key": "my-flag", "version": 5}`))
-// 	}))
-// 	defer sdkServer.Close()
-// 	defer esserver.Close()
+	sdkServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/sdk/latest-flags/my-flag", r.URL.Path)
+		w.Write([]byte(`{"key": "my-flag", "version": 5}`))
+	}))
+	defer sdkServer.Close()
+	defer esserver.Close()
 
-// 	store := NewInMemoryFeatureStore(log.New(ioutil.Discard, "", 0))
+	store := NewInMemoryFeatureStore(log.New(ioutil.Discard, "", 0))
 
-// 	cfg := Config{
-// 		FeatureStore: store,
-// 		StreamUri:    streamServer.URL,
-// 		BaseUri:      sdkServer.URL,
-// 		Logger:       log.New(ioutil.Discard, "", 0),
-// 	}
+	cfg := Config{
+		FeatureStore: store,
+		StreamUri:    streamServer.URL,
+		BaseUri:      sdkServer.URL,
+		Logger:       log.New(ioutil.Discard, "", 0),
+	}
 
-// 	requestor := newRequestor("sdkKey", cfg)
-// 	sp := newStreamProcessor("sdkKey", cfg, requestor)
-// 	defer sp.Close()
+	requestor := newRequestor("sdkKey", cfg)
+	sp := newStreamProcessor("sdkKey", cfg, requestor)
+	defer sp.Close()
 
-// 	closeWhenReady := make(chan struct{})
+	closeWhenReady := make(chan struct{})
 
-// 	sp.Start(closeWhenReady)
+	sp.Start(closeWhenReady)
 
-// 	select {
-// 	case <-closeWhenReady:
-// 	case <-time.After(time.Second):
-// 		assert.Fail(t, "start timeout")
-// 		return
-// 	}
+	select {
+	case <-closeWhenReady:
+	case <-time.After(time.Second):
+		assert.Fail(t, "start timeout")
+		return
+	}
 
-// 	test(events, store)
-// }
+	test(events, store)
+}
 
-// func TestStreamProcessor(t *testing.T) {
-// 	t.Parallel()
-// 	initialPutEvent := &testEvent{
-// 		event: putEvent,
-// 		data: `{"path": "/", "data": {
-// "flags": {"my-flag": {"key": "my-flag", "version": 2}},
-// "segments": {"my-segment": {"key": "my-segment", "version": 5}}
-// }}`,
-// 	}
+func TestStreamProcessor(t *testing.T) {
+	t.Parallel()
+	initialPutEvent := &testEvent{
+		event: putEvent,
+		data: `{"path": "/", "data": {
+"flags": {"my-flag": {"key": "my-flag", "version": 2}},
+"segments": {"my-segment": {"key": "my-segment", "version": 5}}
+}}`,
+	}
 
-// 	t.Run("initial put", func(t *testing.T) {
-// 		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
-// 			waitForVersion(t, store, Features, "my-flag", 2)
-// 		})
-// 	})
+	t.Run("initial put", func(t *testing.T) {
+		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
+			waitForVersion(t, store, Features, "my-flag", 2)
+		})
+	})
 
-// 	t.Run("patch flag", func(t *testing.T) {
-// 		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
-// 			events <- &testEvent{
-// 				event: patchEvent,
-// 				data:  `{"path": "/flags/my-flag", "data": {"key": "my-flag", "version": 3}}`,
-// 			}
+	t.Run("patch flag", func(t *testing.T) {
+		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
+			events <- &testEvent{
+				event: patchEvent,
+				data:  `{"path": "/flags/my-flag", "data": {"key": "my-flag", "version": 3}}`,
+			}
 
-// 			waitForVersion(t, store, Features, "my-flag", 3)
-// 		})
-// 	})
+			waitForVersion(t, store, Features, "my-flag", 3)
+		})
+	})
 
-// 	t.Run("delete flag", func(t *testing.T) {
-// 		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
-// 			events <- &testEvent{
-// 				event: deleteEvent,
-// 				data:  `{"path": "/flags/my-flag", "version": 4}`,
-// 			}
+	t.Run("delete flag", func(t *testing.T) {
+		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
+			events <- &testEvent{
+				event: deleteEvent,
+				data:  `{"path": "/flags/my-flag", "version": 4}`,
+			}
 
-// 			waitForDelete(t, store, Segments, "my-flag")
-// 		})
-// 	})
+			waitForDelete(t, store, Segments, "my-flag")
+		})
+	})
 
-// 	t.Run("patch segment", func(t *testing.T) {
-// 		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
-// 			events <- &testEvent{
-// 				event: patchEvent,
-// 				data:  `{"path": "/segments/my-segment", "data": {"key": "my-segment", "version": 7}}`,
-// 			}
+	t.Run("patch segment", func(t *testing.T) {
+		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
+			events <- &testEvent{
+				event: patchEvent,
+				data:  `{"path": "/segments/my-segment", "data": {"key": "my-segment", "version": 7}}`,
+			}
 
-// 			waitForVersion(t, store, Segments, "my-segment", 7)
-// 		})
-// 	})
+			waitForVersion(t, store, Segments, "my-segment", 7)
+		})
+	})
 
-// 	t.Run("delete segment", func(t *testing.T) {
-// 		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
-// 			events <- &testEvent{
-// 				event: deleteEvent,
-// 				data:  `{"path": "/segments/my-segment", "version": 8}`,
-// 			}
+	t.Run("delete segment", func(t *testing.T) {
+		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
+			events <- &testEvent{
+				event: deleteEvent,
+				data:  `{"path": "/segments/my-segment", "version": 8}`,
+			}
 
-// 			waitForDelete(t, store, Segments, "my-segment")
-// 		})
-// 	})
+			waitForDelete(t, store, Segments, "my-segment")
+		})
+	})
 
-// 	t.Run("indirect flag patch", func(t *testing.T) {
-// 		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
-// 			events <- &testEvent{
-// 				event: indirectPatchEvent,
-// 				data:  "/flags/my-flag",
-// 			}
+	t.Run("indirect flag patch", func(t *testing.T) {
+		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
+			events <- &testEvent{
+				event: indirectPatchEvent,
+				data:  "/flags/my-flag",
+			}
 
-// 			waitForVersion(t, store, Features, "my-flag", 5)
-// 		})
-// 	})
+			waitForVersion(t, store, Features, "my-flag", 5)
+		})
+	})
 
-// }
+}
 
-// func waitForVersion(t *testing.T, store FeatureStore, kind VersionedDataKind, key string, version int) VersionedData {
-// 	var item VersionedData
-// 	var err error
-// 	deadline := time.Now().Add(time.Second * 3)
-// 	for {
-// 		item, err = store.Get(kind, key)
-// 		if err != nil && item.GetVersion() == version || time.Now().After(deadline) {
-// 			break
-// 		}
-// 		time.Sleep(5 * time.Millisecond)
-// 	}
-// 	if assert.NoError(t, err) && assert.NotNil(t, item) && assert.Equal(t, version, item.GetVersion()) {
-// 		return item
-// 	}
-// 	return nil
-// }
+func waitForVersion(t *testing.T, store FeatureStore, kind VersionedDataKind, key string, version int) VersionedData {
+	var item VersionedData
+	var err error
+	deadline := time.Now().Add(time.Second * 3)
+	for {
+		item, err = store.Get(kind, key)
+		if err != nil && item.GetVersion() == version || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if assert.NoError(t, err) && assert.NotNil(t, item) && assert.Equal(t, version, item.GetVersion()) {
+		return item
+	}
+	return nil
+}
 
-// func waitForDelete(t *testing.T, store FeatureStore, kind VersionedDataKind, key string) {
-// 	var item VersionedData
-// 	var err error
-// 	deadline := time.Now().Add(time.Second * 3)
-// 	for {
-// 		item, err = store.Get(kind, key)
-// 		if err != nil && item == nil || time.Now().After(deadline) {
-// 			break
-// 		}
-// 		time.Sleep(5 * time.Millisecond)
-// 	}
-// 	assert.NoError(t, err)
-// 	assert.Nil(t, item)
-// }
+func waitForDelete(t *testing.T, store FeatureStore, kind VersionedDataKind, key string) {
+	var item VersionedData
+	var err error
+	deadline := time.Now().Add(time.Second * 3)
+	for {
+		item, err = store.Get(kind, key)
+		if err != nil && item == nil || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	assert.NoError(t, err)
+	assert.Nil(t, item)
+}
 
 func TestStreamProcessorFailsImmediatelyOn401(t *testing.T) {
 	testStreamProcessorUnrecoverableError(t, 401)

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -12,30 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestStreamProcessor_401ShouldNotBlock(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	defer ts.Close()
-
-	cfg := Config{
-		StreamUri: ts.URL,
-		Logger:    log.New(ioutil.Discard, "", 0),
-	}
-
-	sp := newStreamProcessor("sdkKey", cfg, nil)
-
-	closeWhenReady := make(chan struct{})
-
-	sp.Start(closeWhenReady)
-
-	select {
-	case <-closeWhenReady:
-	case <-time.After(time.Second):
-		assert.Fail(t, "Receiving 401 shouldn't block")
-	}
-}
-
 type testEvent struct {
 	id, event, data string
 }
@@ -54,40 +30,187 @@ func (r *testRepo) Replay(channel, id string) chan eventsource.Event {
 	return c
 }
 
-func runStreamingTest(t *testing.T, initialEvent eventsource.Event, test func(events chan<- eventsource.Event, store FeatureStore)) {
-	esserver := eventsource.NewServer()
-	esserver.ReplayAll = true
-	esserver.Register("test", &testRepo{initialEvent: initialEvent})
-	events := make(chan eventsource.Event, 1000)
-	streamServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/all", r.URL.Path)
-		go func() {
-			for e := range events {
-				esserver.Publish([]string{"test"}, e)
-			}
-		}()
-		esserver.Handler("test").ServeHTTP(w, r)
-	}))
-	defer streamServer.Close()
+// func runStreamingTest(t *testing.T, initialEvent eventsource.Event, test func(events chan<- eventsource.Event, store FeatureStore)) {
+// 	esserver := eventsource.NewServer()
+// 	esserver.ReplayAll = true
+// 	esserver.Register("test", &testRepo{initialEvent: initialEvent})
+// 	events := make(chan eventsource.Event, 1000)
+// 	streamServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// 		assert.Equal(t, "/all", r.URL.Path)
+// 		go func() {
+// 			for e := range events {
+// 				esserver.Publish([]string{"test"}, e)
+// 			}
+// 		}()
+// 		esserver.Handler("test").ServeHTTP(w, r)
+// 	}))
+// 	defer streamServer.Close()
 
-	sdkServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/sdk/latest-flags/my-flag", r.URL.Path)
-		w.Write([]byte(`{"key": "my-flag", "version": 5}`))
-	}))
-	defer sdkServer.Close()
-	defer esserver.Close()
+// 	sdkServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// 		assert.Equal(t, "/sdk/latest-flags/my-flag", r.URL.Path)
+// 		w.Write([]byte(`{"key": "my-flag", "version": 5}`))
+// 	}))
+// 	defer sdkServer.Close()
+// 	defer esserver.Close()
 
-	store := NewInMemoryFeatureStore(log.New(ioutil.Discard, "", 0))
+// 	store := NewInMemoryFeatureStore(log.New(ioutil.Discard, "", 0))
+
+// 	cfg := Config{
+// 		FeatureStore: store,
+// 		StreamUri:    streamServer.URL,
+// 		BaseUri:      sdkServer.URL,
+// 		Logger:       log.New(ioutil.Discard, "", 0),
+// 	}
+
+// 	requestor := newRequestor("sdkKey", cfg)
+// 	sp := newStreamProcessor("sdkKey", cfg, requestor)
+// 	defer sp.Close()
+
+// 	closeWhenReady := make(chan struct{})
+
+// 	sp.Start(closeWhenReady)
+
+// 	select {
+// 	case <-closeWhenReady:
+// 	case <-time.After(time.Second):
+// 		assert.Fail(t, "start timeout")
+// 		return
+// 	}
+
+// 	test(events, store)
+// }
+
+// func TestStreamProcessor(t *testing.T) {
+// 	t.Parallel()
+// 	initialPutEvent := &testEvent{
+// 		event: putEvent,
+// 		data: `{"path": "/", "data": {
+// "flags": {"my-flag": {"key": "my-flag", "version": 2}},
+// "segments": {"my-segment": {"key": "my-segment", "version": 5}}
+// }}`,
+// 	}
+
+// 	t.Run("initial put", func(t *testing.T) {
+// 		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
+// 			waitForVersion(t, store, Features, "my-flag", 2)
+// 		})
+// 	})
+
+// 	t.Run("patch flag", func(t *testing.T) {
+// 		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
+// 			events <- &testEvent{
+// 				event: patchEvent,
+// 				data:  `{"path": "/flags/my-flag", "data": {"key": "my-flag", "version": 3}}`,
+// 			}
+
+// 			waitForVersion(t, store, Features, "my-flag", 3)
+// 		})
+// 	})
+
+// 	t.Run("delete flag", func(t *testing.T) {
+// 		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
+// 			events <- &testEvent{
+// 				event: deleteEvent,
+// 				data:  `{"path": "/flags/my-flag", "version": 4}`,
+// 			}
+
+// 			waitForDelete(t, store, Segments, "my-flag")
+// 		})
+// 	})
+
+// 	t.Run("patch segment", func(t *testing.T) {
+// 		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
+// 			events <- &testEvent{
+// 				event: patchEvent,
+// 				data:  `{"path": "/segments/my-segment", "data": {"key": "my-segment", "version": 7}}`,
+// 			}
+
+// 			waitForVersion(t, store, Segments, "my-segment", 7)
+// 		})
+// 	})
+
+// 	t.Run("delete segment", func(t *testing.T) {
+// 		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
+// 			events <- &testEvent{
+// 				event: deleteEvent,
+// 				data:  `{"path": "/segments/my-segment", "version": 8}`,
+// 			}
+
+// 			waitForDelete(t, store, Segments, "my-segment")
+// 		})
+// 	})
+
+// 	t.Run("indirect flag patch", func(t *testing.T) {
+// 		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
+// 			events <- &testEvent{
+// 				event: indirectPatchEvent,
+// 				data:  "/flags/my-flag",
+// 			}
+
+// 			waitForVersion(t, store, Features, "my-flag", 5)
+// 		})
+// 	})
+
+// }
+
+// func waitForVersion(t *testing.T, store FeatureStore, kind VersionedDataKind, key string, version int) VersionedData {
+// 	var item VersionedData
+// 	var err error
+// 	deadline := time.Now().Add(time.Second * 3)
+// 	for {
+// 		item, err = store.Get(kind, key)
+// 		if err != nil && item.GetVersion() == version || time.Now().After(deadline) {
+// 			break
+// 		}
+// 		time.Sleep(5 * time.Millisecond)
+// 	}
+// 	if assert.NoError(t, err) && assert.NotNil(t, item) && assert.Equal(t, version, item.GetVersion()) {
+// 		return item
+// 	}
+// 	return nil
+// }
+
+// func waitForDelete(t *testing.T, store FeatureStore, kind VersionedDataKind, key string) {
+// 	var item VersionedData
+// 	var err error
+// 	deadline := time.Now().Add(time.Second * 3)
+// 	for {
+// 		item, err = store.Get(kind, key)
+// 		if err != nil && item == nil || time.Now().After(deadline) {
+// 			break
+// 		}
+// 		time.Sleep(5 * time.Millisecond)
+// 	}
+// 	assert.NoError(t, err)
+// 	assert.Nil(t, item)
+// }
+
+func TestStreamProcessorFailsImmediatelyOn401(t *testing.T) {
+	testStreamProcessorUnrecoverableError(t, 401)
+}
+
+func TestStreamProcessorFailsImmediatelyOn403(t *testing.T) {
+	testStreamProcessorUnrecoverableError(t, 403)
+}
+
+func TestStreamProcessorDoesNotFailImmediatelyOn500(t *testing.T) {
+	testStreamProcessorRecoverableError(t, 500)
+}
+
+func testStreamProcessorUnrecoverableError(t *testing.T, statusCode int) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(statusCode)
+	}))
+	defer ts.Close()
 
 	cfg := Config{
-		FeatureStore: store,
-		StreamUri:    streamServer.URL,
-		BaseUri:      sdkServer.URL,
+		StreamUri:    ts.URL,
+		FeatureStore: NewInMemoryFeatureStore(log.New(ioutil.Discard, "", 0)),
 		Logger:       log.New(ioutil.Discard, "", 0),
 	}
 
-	requestor := newRequestor("sdkKey", cfg)
-	sp := newStreamProcessor("sdkKey", cfg, requestor)
+	sp := newStreamProcessor("sdkKey", cfg, nil)
+	defer sp.Close()
 
 	closeWhenReady := make(chan struct{})
 
@@ -95,16 +218,13 @@ func runStreamingTest(t *testing.T, initialEvent eventsource.Event, test func(ev
 
 	select {
 	case <-closeWhenReady:
-	case <-time.After(time.Second):
-		assert.Fail(t, "start timeout")
-		return
+		assert.False(t, sp.Initialized())
+	case <-time.After(time.Second * 3):
+		assert.Fail(t, "Initialization shouldn't block after this error")
 	}
-
-	test(events, store)
 }
 
-func TestStreamProcessor(t *testing.T) {
-	t.Parallel()
+func testStreamProcessorRecoverableError(t *testing.T, statusCode int) {
 	initialPutEvent := &testEvent{
 		event: putEvent,
 		data: `{"path": "/", "data": {
@@ -112,98 +232,37 @@ func TestStreamProcessor(t *testing.T) {
 "segments": {"my-segment": {"key": "my-segment", "version": 5}}
 }}`,
 	}
+	esserver := eventsource.NewServer()
+	esserver.ReplayAll = true
+	esserver.Register("test", &testRepo{initialEvent: initialPutEvent})
 
-	t.Run("initial put", func(t *testing.T) {
-		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
-			waitForVersion(t, store, Features, "my-flag", 2)
-		})
-	})
-
-	t.Run("patch flag", func(t *testing.T) {
-		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
-			events <- &testEvent{
-				event: patchEvent,
-				data:  `{"path": "/flags/my-flag", "data": {"key": "my-flag", "version": 3}}`,
-			}
-
-			waitForVersion(t, store, Features, "my-flag", 3)
-		})
-	})
-
-	t.Run("delete flag", func(t *testing.T) {
-		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
-			events <- &testEvent{
-				event: deleteEvent,
-				data:  `{"path": "/flags/my-flag", "version": 4}`,
-			}
-
-			waitForDelete(t, store, Segments, "my-flag")
-		})
-	})
-
-	t.Run("patch segment", func(t *testing.T) {
-		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
-			events <- &testEvent{
-				event: patchEvent,
-				data:  `{"path": "/segments/my-segment", "data": {"key": "my-segment", "version": 7}}`,
-			}
-
-			waitForVersion(t, store, Segments, "my-segment", 7)
-		})
-	})
-
-	t.Run("delete segment", func(t *testing.T) {
-		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
-			events <- &testEvent{
-				event: deleteEvent,
-				data:  `{"path": "/segments/my-segment", "version": 8}`,
-			}
-
-			waitForDelete(t, store, Segments, "my-segment")
-		})
-	})
-
-	t.Run("indirect flag patch", func(t *testing.T) {
-		runStreamingTest(t, initialPutEvent, func(events chan<- eventsource.Event, store FeatureStore) {
-			events <- &testEvent{
-				event: indirectPatchEvent,
-				data:  "/flags/my-flag",
-			}
-
-			waitForVersion(t, store, Features, "my-flag", 5)
-		})
-	})
-
-}
-
-func waitForVersion(t *testing.T, store FeatureStore, kind VersionedDataKind, key string, version int) VersionedData {
-	var item VersionedData
-	var err error
-	deadline := time.Now().Add(time.Second * 3)
-	for {
-		item, err = store.Get(kind, key)
-		if err != nil && item.GetVersion() == version || time.Now().After(deadline) {
-			break
+	attempt := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempt == 0 {
+			w.WriteHeader(statusCode)
+		} else {
+			esserver.Handler("test").ServeHTTP(w, r)
 		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	if assert.NoError(t, err) && assert.NotNil(t, item) && assert.Equal(t, version, item.GetVersion()) {
-		return item
-	}
-	return nil
-}
+		attempt++
+	}))
+	defer ts.Close()
 
-func waitForDelete(t *testing.T, store FeatureStore, kind VersionedDataKind, key string) {
-	var item VersionedData
-	var err error
-	deadline := time.Now().Add(time.Second * 3)
-	for {
-		item, err = store.Get(kind, key)
-		if err != nil && item == nil || time.Now().After(deadline) {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
+	cfg := Config{
+		StreamUri:    ts.URL,
+		FeatureStore: NewInMemoryFeatureStore(log.New(ioutil.Discard, "", 0)),
+		Logger:       log.New(ioutil.Discard, "", 0),
 	}
-	assert.NoError(t, err)
-	assert.Nil(t, item)
+
+	sp := newStreamProcessor("sdkKey", cfg, nil)
+	defer sp.Close()
+
+	closeWhenReady := make(chan struct{})
+	sp.Start(closeWhenReady)
+
+	select {
+	case <-closeWhenReady:
+		assert.True(t, sp.Initialized())
+	case <-time.After(time.Second * 3):
+		assert.Fail(t, "Should have successfully retried before now")
+	}
 }

--- a/util.go
+++ b/util.go
@@ -139,3 +139,31 @@ func MakeAllVersionedDataMap(
 	}
 	return allData
 }
+
+// Tests whether an HTTP error status represents a condition that might resolve on its own if we retry.
+func isHTTPErrorRecoverable(statusCode int) bool {
+	if statusCode >= 400 && statusCode < 500 {
+		switch statusCode {
+		case 408: // request timeout
+			return true
+		case 429: // too many requests
+			return true
+		default:
+			return false // all other 4xx errors are unrecoverable
+		}
+	}
+	return true
+}
+
+func httpErrorMessage(statusCode int, context string, recoverableMessage string) string {
+	statusDesc := ""
+	if statusCode == 401 {
+		statusDesc = " (invalid SDK key)"
+	}
+	resultMessage := recoverableMessage
+	if !isHTTPErrorRecoverable(statusCode) {
+		resultMessage = "giving up permanently"
+	}
+	return fmt.Sprintf("Received HTTP error %d%s for %s - %s",
+		statusCode, statusDesc, context, resultMessage)
+}


### PR DESCRIPTION
## [4.2.0] - 2018-06-26
### Changed:
- The client now treats most HTTP 4xx errors as unrecoverable: that is, after receiving such an error, it will not make any more HTTP requests for the lifetime of the client instance, in effect taking the client offline. This is because such errors indicate either a configuration problem (invalid SDK key) or a bug, which is not likely to resolve without a restart or an upgrade. This does not apply if the error is 400, 408, 429, or any 5xx error.