### PR TITLE
prepare 4.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the LaunchDarkly Go SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [4.2.2] - 2018-08-03
+### Fixed:
+- Fixed a bug that caused a panic if an I/O error occurred while reading the response body for a polling request.
+- Fixed a bug that caused a panic if a prerequisite feature flag evaluated to a non-scalar value (array or map/hash).
+- Receiving an HTTP 400 error from LaunchDarkly should not make the client give up on sending any more requests to LaunchDarkly (unlike a 401 or 403).
+
 ## [4.2.1] - 2018-06-27
 ### Fixed:
 - Polling processor regressed to polling only once in release 4.1.0.  This has been fixed.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ LaunchDarkly SDK for Go
 
 [![Circle CI](https://circleci.com/gh/launchdarkly/go-client.svg?style=svg)](https://circleci.com/gh/launchdarkly/go-client)
 
+Go runtime compatibility
+-------------------------
+
+This version of the LaunchDarkly SDK has been tested with Go 1.8 through 1.10.
+
 Quick setup
 -----------
 

--- a/event_processor.go
+++ b/event_processor.go
@@ -304,10 +304,9 @@ func (ed *eventDispatcher) isDisabled() bool {
 }
 
 func (ed *eventDispatcher) handleResponse(resp *http.Response) {
-	err := checkStatusCode(resp.StatusCode, resp.Request.URL.String())
-	if err != nil {
+	if isHttpError, err := checkForHttpError(resp.StatusCode, resp.Request.URL.String()); isHttpError {
 		ed.config.Logger.Println(httpErrorMessage(err.Code, "posting events", "some events were dropped"))
-		if err != nil && !isHTTPErrorRecoverable(err.Code) {
+		if !isHTTPErrorRecoverable(err.Code) {
 			ed.stateLock.Lock()
 			defer ed.stateLock.Unlock()
 			ed.disabled = true

--- a/event_processor.go
+++ b/event_processor.go
@@ -304,9 +304,9 @@ func (ed *eventDispatcher) isDisabled() bool {
 }
 
 func (ed *eventDispatcher) handleResponse(resp *http.Response) {
-	if isHttpError, err := checkForHttpError(resp.StatusCode, resp.Request.URL.String()); isHttpError {
-		ed.config.Logger.Println(httpErrorMessage(err.Code, "posting events", "some events were dropped"))
-		if !isHTTPErrorRecoverable(err.Code) {
+	if err := checkForHttpError(resp.StatusCode, resp.Request.URL.String()); err != nil {
+		ed.config.Logger.Println(httpErrorMessage(resp.StatusCode, "posting events", "some events were dropped"))
+		if !isHTTPErrorRecoverable(resp.StatusCode) {
 			ed.stateLock.Lock()
 			defer ed.stateLock.Unlock()
 			ed.disabled = true

--- a/event_processor_test.go
+++ b/event_processor_test.go
@@ -507,6 +507,7 @@ var httpErrorTests = []struct {
 	status      int
 	recoverable bool
 }{
+	{400, true},
 	{401, false},
 	{403, false},
 	{408, true},

--- a/flag.go
+++ b/flag.go
@@ -82,6 +82,7 @@ var Features FeatureFlagVersionedDataKind
 // Rule xpresses a set of AND-ed matching conditions for a user, along with either a fixed
 // variation or a set of rollout percentages
 type Rule struct {
+	Id                 string `json:"id,omitempty" bson:"id,omitempty"`
 	VariationOrRollout `bson:",inline"`
 	Clauses            []Clause `json:"clauses" bson:"clauses"`
 }

--- a/flag.go
+++ b/flag.go
@@ -235,8 +235,7 @@ func (f FeatureFlag) evaluateExplain(user User, store FeatureStore, events *[]Fe
 			}
 
 			*events = append(*events, NewFeatureRequestEvent(prereq.Key, prereqFeatureFlag, user, prereqIndex, prereqValue, nil, &f.Key))
-			variation, verr := prereqFeatureFlag.getVariation(&prereq.Variation)
-			if prereqValue == nil || verr != nil || prereqValue != variation {
+			if prereqIndex == nil || *prereqIndex != prereq.Variation {
 				failedPrereq = &prereq
 			}
 		} else {

--- a/ldclient.go
+++ b/ldclient.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Version is the client version
-const Version = "4.2.1"
+const Version = "4.2.2"
 
 // LDClient is the LaunchDarkly client. Client instances are thread-safe.
 // Applications should instantiate a single instance for the lifetime

--- a/polling.go
+++ b/polling.go
@@ -30,9 +30,10 @@ func (pp *pollingProcessor) Start(closeWhenReady chan<- struct{}) {
 	pp.config.Logger.Printf("Starting LaunchDarkly polling processor with interval: %+v", pp.config.PollInterval)
 
 	ticker := newTickerWithInitialTick(pp.config.PollInterval)
-	defer ticker.Stop()
 
 	go func() {
+		defer ticker.Stop()
+
 		var readyOnce sync.Once
 		notifyReady := func() {
 			readyOnce.Do(func() {

--- a/polling.go
+++ b/polling.go
@@ -51,7 +51,7 @@ func (pp *pollingProcessor) Start(closeWhenReady chan<- struct{}) {
 			case <-ticker.C:
 				if err := pp.poll(); err != nil {
 					pp.config.Logger.Printf("ERROR: Error when requesting feature updates: %+v", err)
-					if hse, ok := err.(*HttpStatusError); ok {
+					if hse, ok := err.(HttpStatusError); ok {
 						pp.config.Logger.Printf("ERROR: %s", httpErrorMessage(hse.Code, "polling request", "will retry"))
 						if !isHTTPErrorRecoverable(hse.Code) {
 							notifyReady()

--- a/polling_test.go
+++ b/polling_test.go
@@ -96,7 +96,7 @@ func TestPollingProcessorRequestResponseCodes(t *testing.T) {
 		statusCode  int
 		recoverable bool
 	}{
-		{400, false},
+		{400, true},
 		{401, false},
 		{403, false},
 		{405, false},

--- a/polling_test.go
+++ b/polling_test.go
@@ -1,6 +1,7 @@
 package ldclient
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -35,45 +36,26 @@ func TestPollingProcessor_ClosingItShouldNotBlock(t *testing.T) {
 	}
 }
 
-func TestPollingProcessor_401ShouldNotBlock(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-
-	defer ts.Close()
-
-	cfg := Config{
-		Logger:       log.New(ioutil.Discard, "", 0),
-		PollInterval: time.Minute,
-		BaseUri:      ts.URL,
-	}
-	req := newFakeRequestor(ts, cfg)
-	p := newPollingProcessor(cfg, req)
-
-	closeWhenReady := make(chan struct{})
-	p.Start(closeWhenReady)
-
-	select {
-	case <-closeWhenReady:
-	case <-time.After(time.Second):
-		assert.Fail(t, "Receiving 401 shouldn't block")
-	}
-}
-
 func TestPollingProcessor_Initialization(t *testing.T) {
+	polls := make(chan struct{}, 2)
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/sdk/latest-all", r.URL.Path)
 		w.Write([]byte(`{"flags": {"my-flag": {"key": "my-flag", "version": 2}}, "segments": {"my-segment": {"key": "my-segment", "version": 3}}}`))
+		if len(polls) < cap(polls) {
+			polls <- struct{}{}
+		}
 	}))
 
 	defer ts.Close()
+	defer ts.CloseClientConnections()
 
 	store := NewInMemoryFeatureStore(log.New(ioutil.Discard, "", 0))
 
 	cfg := Config{
 		FeatureStore: store,
 		Logger:       log.New(ioutil.Discard, "", 0),
-		PollInterval: time.Minute,
+		PollInterval: time.Millisecond,
 		BaseUri:      ts.URL,
 	}
 	req := newFakeRequestor(ts, cfg)
@@ -97,6 +79,80 @@ func TestPollingProcessor_Initialization(t *testing.T) {
 	segment, err := store.Get(Segments, "my-segment")
 	if assert.NoError(t, err) {
 		assert.Equal(t, 3, segment.GetVersion())
+	}
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-polls:
+		case <-time.After(time.Second):
+			assert.Fail(t, "Expected 2 polls but only got %d", i)
+			return
+		}
+	}
+}
+
+func TestPollingProcessorRequestResponseCodes(t *testing.T) {
+	specs := []struct {
+		statusCode  int
+		recoverable bool
+	}{
+		{400, false},
+		{401, false},
+		{403, false},
+		{405, false},
+		{408, true},
+		{429, true},
+		{500, true},
+	}
+
+	for _, tt := range specs {
+		t.Run(fmt.Sprintf("status %d, recoverable %v", tt.statusCode, tt.recoverable), func(t *testing.T) {
+			polls := make(chan struct{}, 2)
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if len(polls) < cap(polls) {
+					polls <- struct{}{}
+				}
+				w.WriteHeader(tt.statusCode)
+			}))
+
+			defer ts.Close()
+			defer ts.CloseClientConnections()
+
+			cfg := Config{
+				Logger:       log.New(ioutil.Discard, "", 0),
+				PollInterval: time.Millisecond * 10,
+				BaseUri:      ts.URL,
+			}
+			req := newFakeRequestor(ts, cfg)
+			p := newPollingProcessor(cfg, req)
+			closeWhenReady := make(chan struct{})
+			p.Start(closeWhenReady)
+
+			if tt.recoverable {
+				// wait for two polls
+				for i := 0; i < 2; i++ {
+					select {
+					case <-polls:
+						t.Logf("Got poll attempt %d/2", i+1)
+					case <-closeWhenReady:
+						assert.Fail(t, "should not report ready")
+						break
+					case <-time.After(time.Second * 3):
+						assert.Fail(t, "failed to retry")
+						break
+					}
+				}
+			} else {
+				select {
+				case <-closeWhenReady:
+					assert.Len(t, polls, 1) // should be ready after a single attempt
+					assert.False(t, p.Initialized())
+				case <-time.After(time.Second):
+					assert.Fail(t, "channel was not closed immediately")
+				}
+			}
+		})
 	}
 }
 

--- a/requestor.go
+++ b/requestor.go
@@ -109,8 +109,7 @@ func (r *requestor) makeRequest(resource string) ([]byte, bool, error) {
 		_ = res.Body.Close()
 	}()
 
-	err := checkStatusCode(res.StatusCode, url)
-	if err != nil {
+	if isHttpError, err := checkForHttpError(res.StatusCode, url); isHttpError {
 		return nil, false, err
 	}
 
@@ -119,7 +118,7 @@ func (r *requestor) makeRequest(resource string) ([]byte, bool, error) {
 	body, ioErr := ioutil.ReadAll(res.Body)
 
 	if ioErr != nil {
-		return nil, false, err
+		return nil, false, ioErr
 	}
 	return body, cached, nil
 }

--- a/requestor.go
+++ b/requestor.go
@@ -109,7 +109,7 @@ func (r *requestor) makeRequest(resource string) ([]byte, bool, error) {
 		_ = res.Body.Close()
 	}()
 
-	if isHttpError, err := checkForHttpError(res.StatusCode, url); isHttpError {
+	if err := checkForHttpError(res.StatusCode, url); err != nil {
 		return nil, false, err
 	}
 

--- a/segment.go
+++ b/segment.go
@@ -60,6 +60,7 @@ var Segments SegmentVersionedDataKind
 
 // SegmentRule describes a set of clauses that
 type SegmentRule struct {
+	Id       string   `json:"id,omitempty" bson:"id,omitempty"`
 	Clauses  []Clause `json:"clauses" bson:"clauses"`
 	Weight   *int     `json:"weight,omitempty" bson:"weight,omitempty"`
 	BucketBy *string  `json:"bucketBy,omitempty" bson:"bucketBy,omitempty"`

--- a/streaming.go
+++ b/streaming.go
@@ -182,9 +182,7 @@ func (sp *streamProcessor) events(closeWhenReady chan<- struct{}) {
 				if sp.checkIfPermanentFailure(err) {
 					sp.closeOnce.Do(func() {
 						sp.config.Logger.Printf("Closing event stream.")
-						// TODO: enable this when we trust stream.Close() never to panic (see https://github.com/donovanhide/eventsource/pull/33)
-						// Until we're able to Close it explicitly here, we won't be able to stop it from trying to reconnect after a 401 error.
-						// sp.stream.Close()
+						sp.stream.Close()
 					})
 					return
 				}

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -185,6 +185,10 @@ func waitForDelete(t *testing.T, store FeatureStore, kind VersionedDataKind, key
 	assert.Nil(t, item)
 }
 
+func TestStreamProcessorDoesNotFailImmediatelyOn400(t *testing.T) {
+	testStreamProcessorRecoverableError(t, 400)
+}
+
 func TestStreamProcessorFailsImmediatelyOn401(t *testing.T) {
 	testStreamProcessorUnrecoverableError(t, 401)
 }

--- a/util.go
+++ b/util.go
@@ -102,25 +102,25 @@ func ToJsonRawMessage(input interface{}) (json.RawMessage, error) {
 	}
 }
 
-func checkStatusCode(statusCode int, url string) *HttpStatusError {
+func checkForHttpError(statusCode int, url string) (bool, HttpStatusError) {
 	if statusCode == http.StatusUnauthorized {
-		return &HttpStatusError{
+		return true, HttpStatusError{
 			Message: fmt.Sprintf("Invalid SDK key when accessing URL: %s. Verify that your SDK key is correct.", url),
 			Code:    statusCode}
 	}
 
 	if statusCode == http.StatusNotFound {
-		return &HttpStatusError{
+		return true, HttpStatusError{
 			Message: fmt.Sprintf("Resource not found when accessing URL: %s. Verify that this resource exists.", url),
 			Code:    statusCode}
 	}
 
 	if statusCode/100 != 2 {
-		return &HttpStatusError{
+		return true, HttpStatusError{
 			Message: fmt.Sprintf("Unexpected response code: %d when accessing URL: %s", statusCode, url),
 			Code:    statusCode}
 	}
-	return nil
+	return false, HttpStatusError{}
 }
 
 // MakeAllVersionedDataMap returns a map of version objects grouped by namespace that can be used to initialize a feature store

--- a/util.go
+++ b/util.go
@@ -102,25 +102,25 @@ func ToJsonRawMessage(input interface{}) (json.RawMessage, error) {
 	}
 }
 
-func checkForHttpError(statusCode int, url string) (bool, HttpStatusError) {
+func checkForHttpError(statusCode int, url string) error {
 	if statusCode == http.StatusUnauthorized {
-		return true, HttpStatusError{
+		return HttpStatusError{
 			Message: fmt.Sprintf("Invalid SDK key when accessing URL: %s. Verify that your SDK key is correct.", url),
 			Code:    statusCode}
 	}
 
 	if statusCode == http.StatusNotFound {
-		return true, HttpStatusError{
+		return HttpStatusError{
 			Message: fmt.Sprintf("Resource not found when accessing URL: %s. Verify that this resource exists.", url),
 			Code:    statusCode}
 	}
 
 	if statusCode/100 != 2 {
-		return true, HttpStatusError{
+		return HttpStatusError{
 			Message: fmt.Sprintf("Unexpected response code: %d when accessing URL: %s", statusCode, url),
 			Code:    statusCode}
 	}
-	return false, HttpStatusError{}
+	return nil
 }
 
 // MakeAllVersionedDataMap returns a map of version objects grouped by namespace that can be used to initialize a feature store

--- a/util.go
+++ b/util.go
@@ -140,10 +140,13 @@ func MakeAllVersionedDataMap(
 	return allData
 }
 
-// Tests whether an HTTP error status represents a condition that might resolve on its own if we retry.
+// Tests whether an HTTP error status represents a condition that might resolve on its own if we retry,
+// or at least should not make us permanently stop sending requests.
 func isHTTPErrorRecoverable(statusCode int) bool {
 	if statusCode >= 400 && statusCode < 500 {
 		switch statusCode {
+		case 400: // bad request
+			return true
 		case 408: // request timeout
 			return true
 		case 429: // too many requests


### PR DESCRIPTION
## [4.2.2] - 2018-08-03
### Fixed:
- Fixed a bug that caused a panic if an I/O error occurred while reading the response body for a polling request.
- Fixed a bug that caused a panic if a prerequisite feature flag evaluated to a non-scalar value (array or map/hash).
- Receiving an HTTP 400 error from LaunchDarkly should not make the client give up on sending any more requests to LaunchDarkly (unlike a 401 or 403).
