### PR TITLE
Make number keys work as in PHP SDK

### DIFF
--- a/util.go
+++ b/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strconv"
 	"time"
 )
 
@@ -62,6 +63,12 @@ func ParseFloat64(input interface{}) *float64 {
 	switch typedInput := input.(type) {
 	case float64:
 		return &typedInput
+	case string:
+		f64, err := strconv.ParseFloat(typedInput, 64)
+		if err != nil {
+			return nil
+		}
+		return &f64
 	default:
 		float64Type := reflect.TypeOf(float64(0))
 		v := reflect.ValueOf(input)

--- a/util_test.go
+++ b/util_test.go
@@ -72,6 +72,9 @@ func TestParseFloat64(t *testing.T) {
 
 	testParseFloat64(t, 4e-2, .04)
 	testParseFloat64(t, 4.0e-2, .04)
+
+	testParseFloat64(t, "1000", 1000)
+	testParseFloat64(t, "1.0", 1.0)
 }
 
 func testParseFloat64(t *testing.T, input interface{}, expected float64) {
@@ -93,7 +96,6 @@ func TestParseBadNumber(t *testing.T) {
 	testParseBadNumber(t, nil)
 	testParseBadNumber(t, "1,000.0")
 	testParseBadNumber(t, "$1000")
-	testParseBadNumber(t, "1000")
 }
 
 func testParseBadNumber(t *testing.T, input interface{}) {


### PR DESCRIPTION
I noticed that I get different resolutions of a feature flag's targeting in a
PHP application and a Go application when using the `greater than or equal to`
operator, when the key is an integer. The PHP application says `true` and the
Go application says `false`. I tracked it down to the `ParseFloat64` function.
I am not sure what the intended behaviour is though, but this makes the code
work the same in both applications. Please let me know if this is the intended
behaviour and the change should go into the PHP SDK instead.

This PR makes it possible to use numbers as keys used in targeting.
The PHP SDK (https://github.com/launchdarkly/php-server-sdk) returns
true for targets as `if key >= 1000`, but the Go SDK returned false.
